### PR TITLE
fix TypeError: str.toLowerCase is not a function.

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,6 +1,6 @@
 export default {
     changeAlias: (alias) => {
-        var str = alias || '';
+        var str = alias.toString() || '';
         str = str.toLowerCase();
         str = str.replace(/à|á|ạ|ả|ã|â|ầ|ấ|ậ|ẩ|ẫ|ă|ằ|ắ|ặ|ẳ|ẵ/g, "a");
         str = str.replace(/è|é|ẹ|ẻ|ẽ|ê|ề|ế|ệ|ể|ễ/g, "e");


### PR DESCRIPTION
fix error "TypeError: str.toLowerCase is not a function. (In 'str.toLowerCase()', 'str.toLowerCase' is undefined)" when param name is a integer